### PR TITLE
Feature/i198-CMakeFlags

### DIFF
--- a/GameBackboneSln/GameBackbone/CMakeLists.txt
+++ b/GameBackboneSln/GameBackbone/CMakeLists.txt
@@ -2,6 +2,8 @@
 
 cmake_minimum_required (VERSION 3.8)
 
+include("${GAMEBACKBONE_TOP_FOLDER}/cmake/Utils/GameBackboneCompilerOptions.cmake")
+
 add_library(GameBackbone SHARED 
 # include
 
@@ -69,6 +71,9 @@ set_target_properties(
     DEBUG_POSTFIX ${CMAKE_DEBUG_POSTFIX}
     VERSION 0.2.1
 )
+
+# Set warnings to GB defaults
+gamebackbone_target_set_default_warnings(GameBackbone)
 
 # Clang Tidy
 option(GAMEBACKBONE_RUN_CLANG_TIDY "Run Clang Tidy when building GB" OFF)

--- a/GameBackboneSln/GameBackbone/Include/GameBackbone/Core/AnimatedSprite.h
+++ b/GameBackboneSln/GameBackbone/Include/GameBackbone/Core/AnimatedSprite.h
@@ -51,7 +51,7 @@ namespace GB {
 
 			//getters
 		unsigned int getCurrentFrame() const;
-		unsigned int getCurrentAnimationId() const;
+		std::size_t getCurrentAnimationId() const;
 		sf::Time getAnimationDelay() const;
 		unsigned int getFramesSpentInCurrentAnimation() const;
 		bool isAnimating() const;

--- a/GameBackboneSln/GameBackbone/Source/Core/AnimatedSprite.cpp
+++ b/GameBackboneSln/GameBackbone/Source/Core/AnimatedSprite.cpp
@@ -98,7 +98,7 @@ unsigned int AnimatedSprite::getCurrentFrame() const {
 /// Returns the ID of the current animation
 /// </summary>
 /// <returns>ID of the current animation.</returns>
-unsigned int AnimatedSprite::getCurrentAnimationId() const {
+std::size_t AnimatedSprite::getCurrentAnimationId() const {
 	return currentAnimationId;
 }
 

--- a/GameBackboneSln/GameBackboneDemo/CMakeLists.txt
+++ b/GameBackboneSln/GameBackboneDemo/CMakeLists.txt
@@ -29,6 +29,9 @@ add_executable(GameBackboneDemo
     "${CMAKE_CURRENT_SOURCE_DIR}/Source/ScaleAndRotationDemoRegion.cpp"
 )
 
+# Set warnings to GB defaults
+gamebackbone_target_set_default_warnings(GameBackboneDemo)
+
 option(GAMEBACKBONE_BUILD_PLATFORM_DEMO "Include the platform Demo in the GB Demo executable (Requires Box2D)" ON)
 if (${GAMEBACKBONE_BUILD_PLATFORM_DEMO})
     # Warn user about Box2D

--- a/GameBackboneSln/GameBackboneDemo/Source/PlatformDemoRegion.cpp
+++ b/GameBackboneSln/GameBackboneDemo/Source/PlatformDemoRegion.cpp
@@ -67,7 +67,7 @@ void PlatformDemoRegion::update(sf::Int64 elapsedTime) {
 		// Update the angle of the sprite to match the angle of the Box2D body.
 		// Converting from radians to degrees because Box2D uses radians and SFML uses degrees. 
 		float32 angle = objectBody->GetAngle();
-		objectSprites[ii]->setRotation(angle * (180.0 / M_PI));
+		objectSprites[ii]->setRotation(angle * (180.0f / M_PI));
 	}
 }
 

--- a/GameBackboneSln/GameBackboneUnitTest/CMakeLists.txt
+++ b/GameBackboneSln/GameBackboneUnitTest/CMakeLists.txt
@@ -24,8 +24,10 @@ add_executable(GameBackboneUnitTest
 	"${CMAKE_CURRENT_SOURCE_DIR}/Source/targetver.h"
 	"${CMAKE_CURRENT_SOURCE_DIR}/Source/UniformAnimationSetTests.cpp"
 	"${CMAKE_CURRENT_SOURCE_DIR}/Source/UtilMathTests.cpp"
-	
 )
+
+# Set warnings to GB defaults
+gamebackbone_target_set_default_warnings(GameBackboneUnitTest)
 
 target_link_libraries(GameBackboneUnitTest PRIVATE GameBackbone)
 

--- a/GameBackboneSln/GameBackboneUnitTest/CMakeLists.txt
+++ b/GameBackboneSln/GameBackboneUnitTest/CMakeLists.txt
@@ -26,8 +26,8 @@ add_executable(GameBackboneUnitTest
 	"${CMAKE_CURRENT_SOURCE_DIR}/Source/UtilMathTests.cpp"
 )
 
-# Set warnings to GB defaults
-gamebackbone_target_set_default_warnings(GameBackboneUnitTest)
+# Set warnings to GB test defaults
+gamebackbone_target_set_default_warnings_for_tests(GameBackboneUnitTest)
 
 target_link_libraries(GameBackboneUnitTest PRIVATE GameBackbone)
 

--- a/GameBackboneSln/GameBackboneUnitTest/Source/AnimationSetTests.cpp
+++ b/GameBackboneSln/GameBackboneUnitTest/Source/AnimationSetTests.cpp
@@ -101,7 +101,7 @@ BOOST_FIXTURE_TEST_CASE(AnimationSet_at_returns_correct_animation, ReusableObjec
 BOOST_FIXTURE_TEST_CASE(AnimationSet_at_throws_when_out_of_bounds, ReusableObjects)
 {
 	AnimationSet animSet({anim1, anim2});
-	BOOST_CHECK_THROW(animSet.at(99).size(), std::out_of_range);
+	BOOST_CHECK_THROW(auto temp = animSet.at(99).size(), std::out_of_range);
 }
 
 BOOST_AUTO_TEST_SUITE_END() // AnimationSet_getters

--- a/GameBackboneSln/GameBackboneUnitTest/Source/PathFinderTests.cpp
+++ b/GameBackboneSln/GameBackboneUnitTest/Source/PathFinderTests.cpp
@@ -272,7 +272,7 @@ BOOST_AUTO_TEST_CASE(Pathfinder_pathFind_single_request_simple_maze) {
 	pathfinder.pathFind(pathRequests, &pathsReturn);
 
 	//ensure the path is not empty
-	BOOST_CHECK(pathsReturn[0].size() >= 0);
+	BOOST_CHECK(pathsReturn[0].size() > 0);
 
 	freeAllNavigationGridData(navGrid);
 }

--- a/GameBackboneSln/cmake/Utils/GameBackboneCompilerOptions.cmake
+++ b/GameBackboneSln/cmake/Utils/GameBackboneCompilerOptions.cmake
@@ -1,0 +1,47 @@
+
+
+function(gamebackbone_target_set_default_warnings IN_TARGET)
+	if(MSVC)
+		# Force to always compile with W4
+		if(CMAKE_CXX_FLAGS MATCHES "/W[0-4]")
+			string(REGEX REPLACE "/W[0-4]" "/W4" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+		else()
+			set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /W4")
+		endif()
+		target_compile_options(${IN_TARGET}
+			PRIVATE
+			# /W4 put this back when we switch to CMake 3.15
+			/wd4251
+		)
+	else()
+		target_compile_options(${IN_TARGET}
+			PRIVATE
+			-Wall
+			-Wextra # reasonable and standard
+			-Wshadow # warn the user if a variable declaration shadows one from a
+					# parent context
+			-Wnon-virtual-dtor # warn the user if a class with virtual functions has a
+							# non-virtual destructor. This helps catch hard to
+							# track down memory errors
+			-Wold-style-cast # warn for c-style casts
+			-Wcast-align # warn for potential performance problem casts
+			-Wunused # warn on anything being unused
+			-Woverloaded-virtual # warn if you overload (not override) a virtual
+								# function
+			-Wpedantic # warn if non-standard C++ is used
+			-Wconversion # warn on type conversions that may lose data
+			-Wsign-conversion # warn on sign conversions
+			-Wmisleading-indentation # warn if identation implies blocks where blocks
+									# do not exist
+			-Wduplicated-cond # warn if if / else chain has duplicated conditions
+			-Wduplicated-branches # warn if if / else branches have duplicated code
+			-Wlogical-op # warn about logical operations being used where bitwise were
+						# probably wanted
+			-Wnull-dereference # warn if a null dereference is detected
+			-Wuseless-cast # warn if you perform a cast to the same type
+			-Wdouble-promotion # warn if float is implicit promoted to double
+			-Wformat=2 # warn on security issues around functions that format output
+					# (ie printf)
+		)
+	endif()
+endfunction()

--- a/GameBackboneSln/cmake/Utils/GameBackboneCompilerOptions.cmake
+++ b/GameBackboneSln/cmake/Utils/GameBackboneCompilerOptions.cmake
@@ -11,7 +11,96 @@ function(gamebackbone_target_set_default_warnings IN_TARGET)
 		target_compile_options(${IN_TARGET}
 			PRIVATE
 			# /W4 put this back when we switch to CMake 3.15
+			/permissive
+			/w14640
+			/w14242
+			/w14254
+			/w14263
+			/w14265
+			/w14287
+			/we4289
+			/w14296
+			/w14311
+			/w14545
+			/w14546
+			/w14547
+			/w14549
+			/w14555
+			# /w14619 there is no warning number xxxx
+			/w14640
+			/w14826
+			/w14905
+			/w14906
+			/w14928
 			/wd4251
+		)
+	else()
+		target_compile_options(${IN_TARGET}
+			PRIVATE
+			-Wall
+			-Wextra # reasonable and standard
+			-Wshadow # warn the user if a variable declaration shadows one from a
+					# parent context
+			-Wnon-virtual-dtor # warn the user if a class with virtual functions has a
+							# non-virtual destructor. This helps catch hard to
+							# track down memory errors
+			-Wold-style-cast # warn for c-style casts
+			-Wcast-align # warn for potential performance problem casts
+			-Wunused # warn on anything being unused
+			-Woverloaded-virtual # warn if you overload (not override) a virtual
+								# function
+			-Wpedantic # warn if non-standard C++ is used
+			-Wconversion # warn on type conversions that may lose data
+			-Wsign-conversion # warn on sign conversions
+			-Wmisleading-indentation # warn if identation implies blocks where blocks
+									# do not exist
+			-Wduplicated-cond # warn if if / else chain has duplicated conditions
+			-Wduplicated-branches # warn if if / else branches have duplicated code
+			-Wlogical-op # warn about logical operations being used where bitwise were
+						# probably wanted
+			-Wnull-dereference # warn if a null dereference is detected
+			-Wuseless-cast # warn if you perform a cast to the same type
+			-Wdouble-promotion # warn if float is implicit promoted to double
+			-Wformat=2 # warn on security issues around functions that format output
+					# (ie printf)
+		)
+	endif()
+endfunction()
+
+function(gamebackbone_target_set_default_warnings_for_tests IN_TARGET)
+	if(MSVC)
+		## Force to always compile with W4
+		#if(CMAKE_CXX_FLAGS MATCHES "/W[0-4]")
+		#	string(REGEX REPLACE "/W[0-4]" "/W4" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+		#else()
+		#	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /W4")
+		#endif()
+		target_compile_options(${IN_TARGET}
+			PRIVATE
+			# /W4 put this back when we switch to CMake 3.15
+			/permissive
+			/w14640
+			/w14242
+			/w14254
+			/w14263
+			#/w14265 too much noise in boost test
+			/w14287
+			/we4289
+			/w14296
+			/w14311
+			/w14545
+			/w14546
+			/w14547
+			/w14549
+			/w14555
+			# /w14619 there is no warning number xxxx
+			/w14640
+			/w14826
+			/w14905
+			/w14906
+			/w14928
+			/wd4251
+			/wd4244
 		)
 	else()
 		target_compile_options(${IN_TARGET}


### PR DESCRIPTION
closes #198
Adds cmake functions for adding warnings to both tests and production code.
Disables warnings that we aren't concerned with.
New warnings are produced by this change, but thats the point.
